### PR TITLE
 feat: 스케줄 완료/되돌리기 수정

### DIFF
--- a/src/main/java/com/sparta/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/sparta/schedule/controller/ScheduleController.java
@@ -50,9 +50,10 @@ public class ScheduleController {
         return scheduleService.deleteSchedule(id, scheduleRequestDto, userDetails);
     }
 
-    @PutMapping("/schedule/complete/{id}")
-    public String updateStatus(@RequestBody CompleteRequestDto requestDto){
-        return scheduleService.updateScheduleStatus(requestDto);
+    @PatchMapping("/schedule/{id}")
+    public String updateCompleteStatus(@PathVariable Long id,
+                               @RequestBody CompleteRequestDto requestDto){
+        return scheduleService.updateCompleteStatus(id, requestDto);
     }
 }
 

--- a/src/main/java/com/sparta/schedule/dto/CompleteRequestDto.java
+++ b/src/main/java/com/sparta/schedule/dto/CompleteRequestDto.java
@@ -1,17 +1,8 @@
 package com.sparta.schedule.dto;
 
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
 public class CompleteRequestDto {
-    private Long id;
-    private boolean isDone;
-
-
-    public CompleteRequestDto(Long id, boolean isDone) {
-        this.id = id;
-        this.isDone = isDone;
-    }
+    private boolean complete;
 }

--- a/src/main/java/com/sparta/schedule/entity/Schedule.java
+++ b/src/main/java/com/sparta/schedule/entity/Schedule.java
@@ -29,7 +29,7 @@ public class Schedule {
 
     private String contents;
 
-    private boolean isDone;
+    private boolean complete;
 
     @ManyToOne
     @JoinColumn(name = "User_Id", nullable = false)
@@ -50,7 +50,7 @@ public class Schedule {
         this.user = user;
     }
 
-    public void updateCompleteStatus(boolean isDone) {
-        this.isDone = isDone;
+    public void updateCompleteStatus(CompleteRequestDto requestDto) {
+        this.complete = requestDto.isComplete();
     }
 }

--- a/src/main/java/com/sparta/schedule/service/ScheduleService.java
+++ b/src/main/java/com/sparta/schedule/service/ScheduleService.java
@@ -37,7 +37,6 @@ public class ScheduleService {
 
     @Transactional
     public ResponseEntity<ScheduleResponseDto> createSchedule(ScheduleRequestDto scheduleRequestDto, UserDetailsImpl userDetails) {
-
         Schedule schedule = scheduleRepository.save(Schedule.builder()
                 .scheduleRequestDto(scheduleRequestDto)
                 .user(userDetails.getUser())
@@ -61,6 +60,7 @@ public class ScheduleService {
     public ResponseEntity<ScheduleResponseDto> updateSchedule(Long id, ScheduleRequestDto scheduleRequestDto, UserDetailsImpl userDetails) {
         Optional<Schedule> found = scheduleRepository.findByIdAndDate(id, scheduleRequestDto.getDate());
         if (found.isEmpty() && userDetails.getUser().getRole() == UserRoleEnum.USER) {
+            // 이거 date 바꾸면 안됨 -> JSON
             throw new IllegalArgumentException("작성자가 일치하지 않습니다.");
         }
 
@@ -78,7 +78,6 @@ public class ScheduleService {
 
     @Transactional
     public ResponseEntity<MegResponseDto> deleteSchedule(Long id, ScheduleRequestDto scheduleRequestDto, UserDetailsImpl userDetails) {
-
         Optional<Schedule> found = scheduleRepository.findByUser(userDetails.getUser());
         if (found.isEmpty() && userDetails.getUser().getRole() == UserRoleEnum.USER) {
             throw new IllegalArgumentException("작성자가 일치하지 않습니다.");
@@ -94,11 +93,12 @@ public class ScheduleService {
                 .body(MegResponseDto.User_ServiceCode(HttpStatus.OK, "삭제 완료"));
     }
 
-    public String updateScheduleStatus(CompleteRequestDto requestDto) {
-        Schedule schedule = scheduleRepository.findById(requestDto.getId()).orElseThrow(
-                () -> new IllegalArgumentException("해당하는 일정이 없습니다.")
-        );
-        schedule.updateCompleteStatus(requestDto.isDone());
-        return "success";
+    @Transactional
+    public String updateCompleteStatus(Long id, CompleteRequestDto requestDto) {
+            Schedule schedule = scheduleRepository.findById(id).orElseThrow(
+                    () -> new IllegalArgumentException("해당하는 일정이 존재하지 않습니다.")
+            );
+                schedule.updateCompleteStatus(requestDto);
+            return "success";
     }
 }

--- a/src/main/java/com/sparta/schedule/service/ScheduleService.java
+++ b/src/main/java/com/sparta/schedule/service/ScheduleService.java
@@ -60,7 +60,6 @@ public class ScheduleService {
     public ResponseEntity<ScheduleResponseDto> updateSchedule(Long id, ScheduleRequestDto scheduleRequestDto, UserDetailsImpl userDetails) {
         Optional<Schedule> found = scheduleRepository.findByIdAndDate(id, scheduleRequestDto.getDate());
         if (found.isEmpty() && userDetails.getUser().getRole() == UserRoleEnum.USER) {
-            // 이거 date 바꾸면 안됨 -> JSON
             throw new IllegalArgumentException("작성자가 일치하지 않습니다.");
         }
 


### PR DESCRIPTION
스케줄 완료 / 되돌리기 기능 수정

- Schedule Controller에서 Mapping을 PUT -> PATCH로 변경

- Schedule Entity에서 변수명을 isDone -> complete로 변경

> 사유1: JAVA의 future interface에 isDone이라는 메서드가 내장되어 있다 하여, 혹시 모를 오류를 피하기 위해)
사유2: boolean 타입 변수의 getter는 getXX()대신 isXX()가 자동 사용되어, 변수명을 isXX로 쓰지 않는다 함)

- Schedule Controller, Service의 메소드 이름 수정